### PR TITLE
Introducing new types of action designators: Constraint designators

### DIFF
--- a/cram_designators/src/facts.lisp
+++ b/cram_designators/src/facts.lisp
@@ -91,7 +91,11 @@
 (def-fact-group manipulation-designator (action-desig)
   (<- (trajectory-desig? ?desig)
     (lisp-pred typep ?desig action-designator)
-    (desig-prop ?desig (type trajectory))))
+    (desig-prop ?desig (type trajectory)))
+
+  (<- (constraints-desig? ?desig)
+      (lisp-pred typep ?desig action-designator)
+      (desig-prop ?desig (type constraints))))
 
 (macrolet ((def-desig-accessor (slot &optional (predicate-name nil))
              (let* ((predicate-name (or predicate-name slot))

--- a/cram_designators/src/package.lisp
+++ b/cram_designators/src/package.lisp
@@ -97,6 +97,7 @@
            #:desig-location-prop
            #:equated-desigs
            #:desig
-           #:trajectory-desig?)
+           #:trajectory-desig?
+           #:constraints-desig?)
   (:desig-properties #:obj #:location #:object #:pose #:of #:at
-                     #:type #:trajectory #:action))
+                     #:type #:trajectory #:action #:constraints))


### PR DESCRIPTION
I'd like to have a new type of action designator, namely constraints designators. I want to clearly separate them from the "regular" trajectory designators in the PR2 manipulation process module. In order to check for these I added a new predicate constraints-desig?.

The changes I made are small. However, since it is cram_core I wanted someone else to explicitly look over my changes. Hence, the pull request. ;)
