### PR TITLE
SBCL is now a debian dependency.

### DIFF
--- a/cram_designators/manifest.xml
+++ b/cram_designators/manifest.xml
@@ -7,7 +7,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_designators</url>
   <review status="unreviewed" notes="" />
-  <depend package="sbcl" />
+  <rosdep name="sbcl" />
   <depend package="alexandria" />
   <depend package="cram_utilities" />
   <depend package="cram_reasoning" />

--- a/cram_execution_trace/manifest.xml
+++ b/cram_execution_trace/manifest.xml
@@ -8,7 +8,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_execution_trace</url>
   <review status="unreviewed" notes=""/>
-  <depend package="sbcl"/>
+  <rosdep name="sbcl"/>
   <depend package="cl_store"/>
   <depend package="cram_utilities"/>
   <depend package="cram_test_utilities"/>  

--- a/cram_math/manifest.xml
+++ b/cram_math/manifest.xml
@@ -8,7 +8,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_math</url>
   <review status="unreviewed" notes=""/>
-  <depend package="sbcl"/>
+  <rosdep name="sbcl"/>
   <depend package="alexandria"/>
   <depend package="gsll"/>
 </package>

--- a/cram_process_modules/manifest.xml
+++ b/cram_process_modules/manifest.xml
@@ -5,7 +5,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_process_modules</url>
   <review status="unreviewed" notes="" />
-  <depend package="sbcl" />
+  <rosdep name="sbcl" />
   <depend package="alexandria" />
   <depend package="cram_designators" />
   <depend package="cram_language" />

--- a/cram_projection/manifest.xml
+++ b/cram_projection/manifest.xml
@@ -11,7 +11,7 @@
   <depend package="alexandria" />
   <depend package="cram_language" />
   <depend package="cram_process_modules" />
-  <depend package="roslisp_runtime" />
+  <rosdep name="sbcl" />
   <depend package="cram_utilities" />
   <depend package="lisp_unit" />
   <depend package="cram_execution_trace" />

--- a/cram_reasoning/manifest.xml
+++ b/cram_reasoning/manifest.xml
@@ -7,7 +7,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_reasoning</url>
   <review status="unreviewed" notes=""/>
-  <depend package="sbcl"/>
+  <rosdep name="sbcl"/>
   <depend package="alexandria"/>
   <depend package="cram_utilities"/>
   <depend package="lisp_unit"/>

--- a/cram_test_utilities/manifest.xml
+++ b/cram_test_utilities/manifest.xml
@@ -8,6 +8,6 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_test_utilities</url>
   <review status="unreviewed" notes=""/>
-  <depend package="sbcl"/>
+  <rosdep name="sbcl"/>
   <depend package="alexandria"/>
 </package>

--- a/cram_utilities/manifest.xml
+++ b/cram_utilities/manifest.xml
@@ -7,7 +7,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/cram_utilities</url>
   <review status="unreviewed" notes="" />
-  <depend package="sbcl" />
+  <rosdep name="sbcl" />
   <depend package="alexandria" />
   <depend package="synchronization_tools" />
   <depend package="lisp_unit" />

--- a/stack.xml
+++ b/stack.xml
@@ -7,6 +7,5 @@
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/cram_core</url>
   <depend stack="ros" />
-  <depend stack="roslisp_support" /> <!-- sbcl -->
 
 </stack>


### PR DESCRIPTION
Same as for cram_highlevel:
- declared sbcl system dependencies
- removed dependencies on roslisp_runtime/roslisp_support
