### PR TITLE
Added the `mapcar-clean` convenience function

### DIFF
--- a/cram_language/src/packages.lisp
+++ b/cram_language/src/packages.lisp
@@ -84,6 +84,7 @@
 #.(let ((cpl-symbols
          '(;; utils
            #:sleep*
+           #:mapcar-clean
            ;; walker
            #:plan-tree-node #:plan-tree-node-sexp #:plan-tree-node-parent
            #:plan-tree-node-children #:plan-tree-node-path

--- a/cram_language/src/utils.lisp
+++ b/cram_language/src/utils.lisp
@@ -100,3 +100,9 @@
             (when (plusp seconds)
               (go :retry)))))))
 
+(defmacro mapcar-clean (function list &rest more-lists)
+  "Automatically removes all `NIL' entries from a generated list after
+performing a `mapcar'."
+  (if more-lists
+      `(remove-if #'not (mapcar ,function ,list ,more-lists))
+      `(remove-if #'not (mapcar ,function ,list))))


### PR DESCRIPTION
`mapcar-clean` removes all `nil` entries from the resulting list.
