### PR TITLE
Shadow the extremum function

### DIFF
--- a/cram_execution_trace/src/package.lisp
+++ b/cram_execution_trace/src/package.lisp
@@ -36,6 +36,7 @@
         :alexandria
         :cram-utilities
         :cram-language-implementation)
+  (:shadowing-import-from :cram-utilities #:extremum)
   (:export
    ;; durable-copy.lisp
    #:durable-copy

--- a/cram_language/src/packages.lisp
+++ b/cram_language/src/packages.lisp
@@ -240,6 +240,7 @@
                :cram-utilities
                :trivial-garbage
                :alexandria)
+         (:shadowing-import-from :cram-utilities #:extremum)
          (:export ,@cpl-symbols ,@fluent-ops ,@cpl-impl-ext-symbols))
 
        (defpackage :cram-language

--- a/cram_language/tests/package.lisp
+++ b/cram_language/tests/package.lisp
@@ -39,4 +39,5 @@
         :fiveam
         :alexandria)
   (:import-from #:cram-walker #:make-plan-tree-node)
+  (:shadowing-import-from :cram-utilities #:extremum)
   (:shadowing-import-from :cram-language-implementation #:fail))

--- a/cram_utilities/src/package.lisp
+++ b/cram_utilities/src/package.lisp
@@ -79,6 +79,7 @@
 
 (defpackage :cram-utilities
   (:use :common-lisp :alexandria)
+  (:shadow #:extremum)
   (:nicknames :cut)
   #.`(:import-from :sb-thread             #:thread ,@+semaphore-symbols+)
   #.`(:import-from :sb-concurrency        ,@+queue-symbols+)

--- a/cram_utilities/tests/package.lisp
+++ b/cram_utilities/tests/package.lisp
@@ -37,4 +37,5 @@
         #:cram-utilities
         #:lisp-unit
         #:alexandria)
+  (:shadow #:extremum)
   (:shadowing-import-from #:lisp-unit set-equal))


### PR DESCRIPTION
Newer versions of alexandria export a function of the same name. To
remove this conflict, the symbol from alexandria will be shadowed.